### PR TITLE
Player petting and prober networking in 1.18

### DIFF
--- a/src/main/java/net/ellivers/pettable/Pettable.java
+++ b/src/main/java/net/ellivers/pettable/Pettable.java
@@ -4,8 +4,12 @@ import me.shedaniel.autoconfig.AutoConfig;
 import me.shedaniel.autoconfig.serializer.GsonConfigSerializer;
 import net.ellivers.pettable.config.ModConfig;
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.networking.v1.PlayerLookup;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.fabricmc.fabric.api.tag.TagFactory;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
+import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.tag.Tag;
 import net.minecraft.util.Identifier;
 
@@ -25,5 +29,15 @@ public class Pettable implements ModInitializer {
 
 		AutoConfig.register(ModConfig.class, GsonConfigSerializer::new);
 
+		ServerPlayNetworking.registerGlobalReceiver(new Identifier(MOD_ID,"client_pet"), (server, player, handler, buf, sender) -> {
+			Entity target = player.getEntityWorld().getEntityById(buf.readInt());
+			server.execute(() -> {
+				System.out.println("pettable: if this shows up in the client log something went wrong");
+				for (ServerPlayerEntity entity: PlayerLookup.tracking(target))
+					ServerPlayNetworking.send(entity,new Identifier(MOD_ID,"server_pet"),buf);
+
+			});
+
+		});
 	}
 }

--- a/src/main/java/net/ellivers/pettable/Pettable.java
+++ b/src/main/java/net/ellivers/pettable/Pettable.java
@@ -4,12 +4,8 @@ import me.shedaniel.autoconfig.AutoConfig;
 import me.shedaniel.autoconfig.serializer.GsonConfigSerializer;
 import net.ellivers.pettable.config.ModConfig;
 import net.fabricmc.api.ModInitializer;
-import net.fabricmc.fabric.api.networking.v1.PlayerLookup;
-import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.fabricmc.fabric.api.tag.TagFactory;
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
-import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.tag.Tag;
 import net.minecraft.util.Identifier;
 
@@ -29,15 +25,5 @@ public class Pettable implements ModInitializer {
 
 		AutoConfig.register(ModConfig.class, GsonConfigSerializer::new);
 
-		ServerPlayNetworking.registerGlobalReceiver(new Identifier(MOD_ID,"client_pet"), (server, player, handler, buf, sender) -> {
-			Entity target = player.getEntityWorld().getEntityById(buf.readInt());
-			server.execute(() -> {
-				System.out.println("pettable: if this shows up in the client log something went wrong");
-				for (ServerPlayerEntity entity: PlayerLookup.tracking(target))
-					ServerPlayNetworking.send(entity,new Identifier(MOD_ID,"server_pet"),buf);
-
-			});
-
-		});
 	}
 }

--- a/src/main/java/net/ellivers/pettable/client/PettableClient.java
+++ b/src/main/java/net/ellivers/pettable/client/PettableClient.java
@@ -1,0 +1,53 @@
+package net.ellivers.pettable.client;
+
+import net.ellivers.pettable.Pettable;
+import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientEntityEvents;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
+import net.minecraft.client.world.ClientEntityManager;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.mob.SlimeEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.particle.ParticleTypes;
+import net.minecraft.sound.SoundEvents;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.world.World;
+
+import java.util.Random;
+
+
+public class PettableClient implements ClientModInitializer {
+    @Override
+    public void onInitializeClient() {
+        ClientPlayNetworking.registerGlobalReceiver(new Identifier(Pettable.MOD_ID,"server_pet"), (client, handler, buf, responseSender) -> {
+            Entity target = handler.getWorld().getEntityById(buf.readInt());
+            client.execute(() -> {
+                spawnHearts(client.world, target);
+            });
+        });
+    }
+
+    private final Random petRandom = new Random();
+    private void spawnHearts(World world, Entity entity) {
+        if (entity instanceof SlimeEntity) {
+            int i = ((SlimeEntity) entity).getSize();
+
+            if (!entity.isInvisible()) for(int j = 0; j < i * 8; ++j) {
+                float f = petRandom.nextFloat() * 6.2831855F;
+                float g = petRandom.nextFloat() * 0.5F + 0.5F;
+                float h = MathHelper.sin(f) * (float)i * 0.5F * g;
+                float k = MathHelper.cos(f) * (float)i * 0.5F * g;
+                world.addParticle(ParticleTypes.ITEM_SLIME, entity.getX() + (double)h, entity.getY(), entity.getZ() + (double)k, 0.0D, 0.0D, 0.0D);
+            }
+
+            if (!entity.isSilent()) entity.playSound(SoundEvents.ENTITY_SLIME_SQUISH_SMALL, 0.4F * (float)i, ((petRandom.nextFloat() - petRandom.nextFloat()) * 0.2F + 1.0F) / 0.8F);
+            ((SlimeEntity) entity).targetStretch = -0.5F;
+        }
+        double d = petRandom.nextGaussian() * 0.02D;
+        double e = petRandom.nextGaussian() * 0.02D;
+        double f = petRandom.nextGaussian() * 0.02D;
+        for (int k = 0; k < 3; ++k)
+            world.addParticle(ParticleTypes.HEART, entity.getParticleX(1.0D), entity instanceof PlayerEntity ? entity.getY() + 0.5D : entity.getEyeY(), entity.getParticleZ(1.0D), d, e, f);
+    }
+}

--- a/src/main/java/net/ellivers/pettable/client/PettableClient.java
+++ b/src/main/java/net/ellivers/pettable/client/PettableClient.java
@@ -2,9 +2,7 @@ package net.ellivers.pettable.client;
 
 import net.ellivers.pettable.Pettable;
 import net.fabricmc.api.ClientModInitializer;
-import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientEntityEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
-import net.minecraft.client.world.ClientEntityManager;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.mob.SlimeEntity;
 import net.minecraft.entity.player.PlayerEntity;
@@ -21,7 +19,10 @@ public class PettableClient implements ClientModInitializer {
     @Override
     public void onInitializeClient() {
         ClientPlayNetworking.registerGlobalReceiver(new Identifier(Pettable.MOD_ID,"server_pet"), (client, handler, buf, responseSender) -> {
-            Entity target = handler.getWorld().getEntityById(buf.readInt());
+            boolean player = buf.readBoolean();
+
+            Entity target = player ? handler.getWorld().getPlayerByUuid(buf.readUuid()) : handler.getWorld().getEntityById(buf.readInt());
+
             client.execute(() -> {
                 spawnHearts(client.world, target);
             });
@@ -41,7 +42,6 @@ public class PettableClient implements ClientModInitializer {
                 world.addParticle(ParticleTypes.ITEM_SLIME, entity.getX() + (double)h, entity.getY(), entity.getZ() + (double)k, 0.0D, 0.0D, 0.0D);
             }
 
-            if (!entity.isSilent()) entity.playSound(SoundEvents.ENTITY_SLIME_SQUISH_SMALL, 0.4F * (float)i, ((petRandom.nextFloat() - petRandom.nextFloat()) * 0.2F + 1.0F) / 0.8F);
             ((SlimeEntity) entity).targetStretch = -0.5F;
         }
         double d = petRandom.nextGaussian() * 0.02D;

--- a/src/main/java/net/ellivers/pettable/mixin/PlayerEntityMixin.java
+++ b/src/main/java/net/ellivers/pettable/mixin/PlayerEntityMixin.java
@@ -41,6 +41,7 @@ public abstract class PlayerEntityMixin implements Angerable {
     public void interact(Entity entity, Hand hand, CallbackInfoReturnable<ActionResult> cir) {
         if ((entity instanceof PassiveEntity
                 || entity instanceof AmbientEntity
+                || entity instanceof PlayerEntity
                 || entity instanceof WaterCreatureEntity
                 || (entity instanceof SlimeEntity && !(entity instanceof MagmaCubeEntity) && ((SlimeEntity) entity).isSmall()))
                 && checkPlayer(((PlayerEntity) (Object) this), hand)) {
@@ -49,7 +50,7 @@ public abstract class PlayerEntityMixin implements Angerable {
                 EntityType<?> type = entity.getType();
 
                 // Special case for angery entities
-                if (entity instanceof Angerable) {
+                if (!(entity instanceof PlayerEntity) && entity instanceof Angerable) {
                     if (!((Angerable) entity).hasAngerTime()) {
                         successfullyPet(entity.getEntityWorld(), entity);
                         cir.setReturnValue(ActionResult.SUCCESS);
@@ -90,14 +91,16 @@ public abstract class PlayerEntityMixin implements Angerable {
             ((SlimeEntity) entity).targetStretch = -0.5F;
         }
 
-        if (!entity.isSilent()) {
-            ((MobEntity) entity).ambientSoundChance = -((MobEntity) entity).getMinAmbientSoundDelay();
-            ((MobEntity) entity).playAmbientSound();
-        }
-        if (AutoConfig.getConfigHolder(ModConfig.class).getConfig().heal_owner && entity instanceof TameableEntity && ((TameableEntity) entity).isOwner((LivingEntity) (Object) this)) {
-            ((TameableEntity) entity).heal(2);
-            ((LivingEntity) (Object) this).heal(2);
-            spawnHearts(world, (LivingEntity) (Object) this);
+        if (!(entity instanceof PlayerEntity)) {
+            if (!entity.isSilent()) {
+                ((MobEntity) entity).ambientSoundChance = -((MobEntity) entity).getMinAmbientSoundDelay();
+                ((MobEntity) entity).playAmbientSound();
+            }
+            if (AutoConfig.getConfigHolder(ModConfig.class).getConfig().heal_owner && entity instanceof TameableEntity && ((TameableEntity) entity).isOwner((LivingEntity) (Object) this)) {
+                ((TameableEntity) entity).heal(2);
+                ((LivingEntity) (Object) this).heal(2);
+                spawnHearts(world, (LivingEntity) (Object) this);
+            }
         }
         spawnHearts(world, entity);
     }

--- a/src/main/java/net/ellivers/pettable/mixin/PlayerEntityMixin.java
+++ b/src/main/java/net/ellivers/pettable/mixin/PlayerEntityMixin.java
@@ -2,30 +2,24 @@ package net.ellivers.pettable.mixin;
 
 import me.shedaniel.autoconfig.AutoConfig;
 import net.ellivers.pettable.config.ModConfig;
-import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
 import net.fabricmc.fabric.api.networking.v1.PlayerLookup;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
-import net.minecraft.entity.damage.DamageSource;
-import net.minecraft.entity.effect.StatusEffectInstance;
-import net.minecraft.entity.effect.StatusEffects;
 import net.minecraft.entity.mob.*;
 import net.minecraft.entity.passive.PassiveEntity;
 import net.minecraft.entity.passive.PufferfishEntity;
 import net.minecraft.entity.passive.TameableEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.network.PacketByteBuf;
-import net.minecraft.network.packet.s2c.play.GameStateChangeS2CPacket;
-import net.minecraft.particle.ParticleTypes;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
 import net.minecraft.sound.SoundEvents;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
 import net.minecraft.util.Identifier;
-import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -71,7 +65,7 @@ public abstract class PlayerEntityMixin implements Angerable {
                 else if (entity instanceof PufferfishEntity && ((PufferfishEntity) entity).getPuffState() > 0) {
                     entity.onPlayerCollision((PlayerEntity) (Object) this);
                     cir.setReturnValue(ActionResult.SUCCESS);
-                } else if (!type.isIn(NOT_PETTABLE) && !(type.isIn(NOT_PETTABLE_ADULT) && !((MobEntity) entity).isBaby())) {
+                } else if (!type.isIn(NOT_PETTABLE) && !(type.isIn(NOT_PETTABLE_ADULT) && entity instanceof MobEntity && !((MobEntity) entity).isBaby())) {
                     successfullyPet(entity.getEntityWorld(), entity);
                     cir.setReturnValue(ActionResult.SUCCESS);
                 }
@@ -89,17 +83,7 @@ public abstract class PlayerEntityMixin implements Angerable {
 
         if (entity instanceof SlimeEntity) {
             int i = ((SlimeEntity) entity).getSize();
-
-            if (!entity.isInvisible()) for(int j = 0; j < i * 8; ++j) {
-                float f = petRandom.nextFloat() * 6.2831855F;
-                float g = petRandom.nextFloat() * 0.5F + 0.5F;
-                float h = MathHelper.sin(f) * (float)i * 0.5F * g;
-                float k = MathHelper.cos(f) * (float)i * 0.5F * g;
-                entity.world.addParticle(ParticleTypes.ITEM_SLIME, entity.getX() + (double)h, entity.getY(), entity.getZ() + (double)k, 0.0D, 0.0D, 0.0D);
-            }
-
             if (!entity.isSilent()) entity.playSound(SoundEvents.ENTITY_SLIME_SQUISH_SMALL, 0.4F * (float)i, ((petRandom.nextFloat() - petRandom.nextFloat()) * 0.2F + 1.0F) / 0.8F);
-            ((SlimeEntity) entity).targetStretch = -0.5F;
         }
 
         if (!(entity instanceof PlayerEntity)) {
@@ -110,23 +94,26 @@ public abstract class PlayerEntityMixin implements Angerable {
             if (AutoConfig.getConfigHolder(ModConfig.class).getConfig().heal_owner && entity instanceof TameableEntity && ((TameableEntity) entity).isOwner((LivingEntity) (Object) this)) {
                 ((TameableEntity) entity).heal(2);
                 ((LivingEntity) (Object) this).heal(2);
-                spawnHearts(world, (LivingEntity) (Object) this);
+                networkPet(world, (PlayerEntity) (Object) this);
             }
         }
-        spawnHearts(world, entity);
-        if(world.isClient() ){
-            PacketByteBuf buf = PacketByteBufs.create();
-            buf.writeInt(entity.getId());
-            ClientPlayNetworking.send(new Identifier(MOD_ID,"client_pet"), buf);
-        }
+        networkPet(world, entity);
     }
 
-    private void spawnHearts(World world, Entity entity) {
-        double d = petRandom.nextGaussian() * 0.02D;
-        double e = petRandom.nextGaussian() * 0.02D;
-        double f = petRandom.nextGaussian() * 0.02D;
-        for (int k = 0; k < 3; ++k)
-            world.addParticle(ParticleTypes.HEART, entity.getParticleX(1.0D), entity instanceof PlayerEntity ? entity.getY() + 0.5D : entity.getEyeY(), entity.getParticleZ(1.0D), d, e, f);
+    private void networkPet(World world, Entity entity) {
+        if(!world.isClient() ){
+            PacketByteBuf buf = PacketByteBufs.create();
+            if(entity instanceof PlayerEntity){
+                buf.writeBoolean(true);
+                buf.writeUuid(PlayerEntity.getUuidFromProfile(((PlayerEntity)entity).getGameProfile()));
+            }else{
+                buf.writeBoolean(false);
+                buf.writeInt(entity.getId());
+            }
+            for (ServerPlayerEntity player : PlayerLookup.tracking((ServerWorld) entity.getEntityWorld(),entity.getBlockPos())){
+                ServerPlayNetworking.send(player, new Identifier(MOD_ID, "server_pet"), buf);
+            }
+        }
     }
 
 }

--- a/src/main/java/net/ellivers/pettable/mixin/PlayerEntityMixin.java
+++ b/src/main/java/net/ellivers/pettable/mixin/PlayerEntityMixin.java
@@ -2,18 +2,29 @@ package net.ellivers.pettable.mixin;
 
 import me.shedaniel.autoconfig.AutoConfig;
 import net.ellivers.pettable.config.ModConfig;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
+import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
+import net.fabricmc.fabric.api.networking.v1.PlayerLookup;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.damage.DamageSource;
+import net.minecraft.entity.effect.StatusEffectInstance;
+import net.minecraft.entity.effect.StatusEffects;
 import net.minecraft.entity.mob.*;
 import net.minecraft.entity.passive.PassiveEntity;
 import net.minecraft.entity.passive.PufferfishEntity;
 import net.minecraft.entity.passive.TameableEntity;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.network.packet.s2c.play.GameStateChangeS2CPacket;
 import net.minecraft.particle.ParticleTypes;
+import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.sound.SoundEvents;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
+import net.minecraft.util.Identifier;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
@@ -103,6 +114,11 @@ public abstract class PlayerEntityMixin implements Angerable {
             }
         }
         spawnHearts(world, entity);
+        if(world.isClient() ){
+            PacketByteBuf buf = PacketByteBufs.create();
+            buf.writeInt(entity.getId());
+            ClientPlayNetworking.send(new Identifier(MOD_ID,"client_pet"), buf);
+        }
     }
 
     private void spawnHearts(World world, Entity entity) {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -22,6 +22,9 @@
     ],
     "main": [
       "net.ellivers.pettable.Pettable"
+    ],
+    "client": [
+      "net.ellivers.pettable.client.PettableClient"
     ]
   },
   "mixins": [


### PR DESCRIPTION
Why?: Some people on a server we're on would like to pet each other very much, while implementing that we noticed that particles and slime squish effects aren't networked and did so ourselves. Although some private servers might want player petting we don't trust public servers with it.

Recommendations before merging: Move player petting to a config entry excluding the feature by default, or just removing the feature entirely so people don't be weird about it and to restrain the feature to only places where people are comfortable with that.

Current status, functional: the networking is honestly not very different from the system vanilla uses on some entities, if only said system had the heart particle event on all entities and was easily hijackable for this but alas. we probably could move the player petting to a config ourselves.
